### PR TITLE
Update Farcaster manifest with new account association

### DIFF
--- a/app/.well-known/farcaster.json/route.ts
+++ b/app/.well-known/farcaster.json/route.ts
@@ -16,9 +16,9 @@ export async function GET() {
 
   return Response.json({
     accountAssociation: {
-      header: process.env.FARCASTER_HEADER || "",
-      payload: process.env.FARCASTER_PAYLOAD || "",
-      signature: process.env.FARCASTER_SIGNATURE || "",
+      header: process.env.FARCASTER_HEADER || "eyJmaWQiOjQxODY3MSwidHlwZSI6ImN1c3RvZHkiLCJrZXkiOiIweDFGRGUyN0YwMjM5YmY3OTA5OTdlRjRlNzQ5RWRCRDY2M0Y3NTU4RmIifQ",
+      payload: process.env.FARCASTER_PAYLOAD || "eyJkb21haW4iOiJnaWZub3Vucy5mcmVlemVydmVyc2UuY29tIn0",
+      signature: process.env.FARCASTER_SIGNATURE || "MHg5Yzg0YjgzNjQxMTUxOTI3OTBhM2E2ZmRkYjViMDE3MjY5YWUwZDc0Y2E4NjgxNzBmZGMxMzMyNmRmODBmZmRlNzFjZGU2MjMwNTJlYjJmNDg3ZDc3NTVlYjJjZDczZTI4MDg0NzJkZmI1Y2FiMmJlNjZlMDE4YTQ0NzQ5YjE5MTFi",
     },
     frame: withValidProperties({
       version: "1",


### PR DESCRIPTION
- Add new account association header, payload, and signature as fallback values
- Environment variables still take precedence if set
- Ensures manifest works with proper cryptographic signature for domain verification
- FID: 418671 associated with gifnouns.freezerverse.com domain