### PR TITLE
Fix Farcaster Mini App metadata and manifest configuration

### DIFF
--- a/app/api/farcaster-manifest/route.ts
+++ b/app/api/farcaster-manifest/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  const manifest = {
+    "accountAssociation": {
+      "header": "eyJmaWQiOjQxODY3MSwidHlwZSI6ImN1c3RvZHkiLCJrZXkiOiIweDFGRGUyN0YwMjM5YmY3OTA5OTdlRjRlNzQ5RWRCRDY2M0Y3NTU4RmIifQ",
+      "payload": "eyJkb21haW4iOiJnaWZub3Vucy5mcmVlemVydmVyc2UuY29tIn0",
+      "signature": "MHg5Yzg0YjgzNjQxMTUxOTI3OTBhM2E2ZmRkYjViMDE3MjY5YWUwZDc0Y2E4NjgxNzBmZGMxMzMyNmRmODBmZmRlNzFjZGU2MjMwNTJlYjJmNDg3ZDc3NTVlYjJjZDczZTI4MDg0NzJkZmI1Y2FiMmJlNjZlMDE4YTQ0NzQ5YjE5MTFi"
+    },
+    "miniapp": {
+      "version": "1",
+      "name": "GifNouns",
+      "iconUrl": "https://gifnouns.freezerverse.com/icon.png",
+      "homeUrl": "https://gifnouns.freezerverse.com",
+      "splashImageUrl": "https://gifnouns.freezerverse.com/splash.png",
+      "splashBackgroundColor": "#8B5CF6",
+      "subtitle": "Animate your Nouns PFP",
+      "description": "Create animated Nouns with custom noggles and eye animations. Upload your Noun PFP and transform it into animated art with unique color combinations and dynamic eyes.",
+      "screenshotUrls": [
+        "https://gifnouns.freezerverse.com/screenshot.png"
+      ],
+      "primaryCategory": "art-creativity",
+      "tags": [
+        "nouns",
+        "animation",
+        "pfp",
+        "gif",
+        "art"
+      ],
+      "heroImageUrl": "https://gifnouns.freezerverse.com/hero.png",
+      "tagline": "Bring your Nouns to life",
+      "ogTitle": "GifNouns - Animated Nouns",
+      "ogDescription": "Create animated Nouns with custom noggles and eyes animations",
+      "ogImageUrl": "https://gifnouns.freezerverse.com/hero.png",
+      "imageUrl": "https://gifnouns.freezerverse.com/hero.png",
+      "buttonTitle": "Animate your nouns ⌐◨-◨",
+      "requiredChains": [
+        "eip155:1",
+        "eip155:8453"
+      ],
+      "requiredCapabilities": [
+        "wallet.getEthereumProvider",
+        "actions.signIn"
+      ],
+      "noindex": false
+    }
+  };
+
+  return NextResponse.json(manifest, {
+    headers: {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type',
+    },
+  });
+}
+
+export async function OPTIONS() {
+  return new NextResponse(null, {
+    status: 200,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type',
+    },
+  });
+}

--- a/app/components/providers/SDKProvider.tsx
+++ b/app/components/providers/SDKProvider.tsx
@@ -3,6 +3,15 @@
 import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
 import { sdk } from '@farcaster/miniapp-sdk';
 
+// Debug SDK import
+console.log('🔧 SDK import check:', {
+  sdk: !!sdk,
+  sdkType: typeof sdk,
+  sdkKeys: sdk ? Object.keys(sdk) : 'undefined',
+  actions: sdk?.actions ? Object.keys(sdk.actions) : 'undefined',
+  haptics: sdk?.haptics ? Object.keys(sdk.haptics) : 'undefined'
+});
+
 interface SDKContextType {
   isSDKReady: boolean;
   sdkError: string | null;
@@ -60,8 +69,8 @@ export function SDKProvider({ children }: SDKProviderProps) {
         // Still try to initialize but expect limited functionality
       }
 
-      // Just mark as initialized, don't call ready() yet
-      console.log('✅ Farcaster MiniApp SDK initialized (ready() will be called later)');
+      // Mark as initialized
+      console.log('✅ Farcaster MiniApp SDK initialized');
       setIsInitialized(true);
       setSDKError(null);
       
@@ -91,7 +100,7 @@ export function SDKProvider({ children }: SDKProviderProps) {
     }
   };
 
-  // Separate function to call ready() - this should be called after app is fully loaded
+  // Function to call ready() - simplified logic
   const callReady = async () => {
     if (!isInitialized) {
       console.log('⚠️ SDK not initialized yet, cannot call ready()');
@@ -105,6 +114,10 @@ export function SDKProvider({ children }: SDKProviderProps) {
 
     try {
       console.log('📞 Calling sdk.actions.ready() to display app...');
+      console.log('🔧 SDK object available:', !!sdk);
+      console.log('🔧 SDK actions available:', !!sdk.actions);
+      console.log('🔧 SDK ready function available:', typeof sdk.actions.ready);
+      
       await sdk.actions.ready();
       
       console.log('✅ sdk.actions.ready() called successfully!');

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,11 +31,6 @@ export async function generateMetadata(): Promise<Metadata> {
       images: [`${URL}/hero.png`],
     },
     other: {
-      "fc:frame": URL,
-      "fc:frame:image": `${URL}/hero.png`,
-      "fc:frame:button:1": "Create GifNoun",
-      "fc:frame:button:2": "View Gallery",
-      "fc:frame:post_url": URL,
       "fc:miniapp": JSON.stringify({
         version: "1",
         name: "GifNouns",


### PR DESCRIPTION
- Add Farcaster manifest API route for proper manifest serving
- Fix environment variable loading for production URLs in metadata
- Ensure fc:miniapp metadata uses correct production domain URLs
- Resolve 'Preview not available' error in Farcaster validation